### PR TITLE
Change the signature of onTileLoaded method in TileLoadedListener interface

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/modules/MapTileDownloader.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/modules/MapTileDownloader.java
@@ -2,6 +2,7 @@ package com.mapbox.mapboxsdk.tileprovider.modules;
 
 import android.graphics.drawable.Drawable;
 import android.util.Log;
+
 import com.mapbox.mapboxsdk.geometry.BoundingBox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.tileprovider.MapTile;
@@ -14,8 +15,8 @@ import com.mapbox.mapboxsdk.util.AppUtils;
 import com.mapbox.mapboxsdk.views.MapView;
 import com.mapbox.mapboxsdk.views.util.TileLoadedListener;
 import com.mapbox.mapboxsdk.views.util.TilesLoadedListener;
+
 import java.util.concurrent.atomic.AtomicReference;
-import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
 
 /**
  * The {@link MapTileDownloader} loads tiles from an HTTP server.
@@ -163,9 +164,5 @@ public class MapTileDownloader extends MapTileModuleLayerBase {
 //            Log.d(TAG, "tileLayer.getDrawable() returning result = '" + result + "'");
             return result;
         }
-    }
-
-    private CacheableBitmapDrawable onTileLoaded(CacheableBitmapDrawable pDrawable) {
-        return mMapView.getTileLoadedListener().onTileLoaded(pDrawable);
     }
 }

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/tileprovider/tilesource/WebSourceTileLayer.java
@@ -119,6 +119,7 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
                 if (listener != null) {
                     listener.onTilesLoadStarted();
                 }
+
                 for (final String url : urls) {
                     Bitmap bitmap = getBitmapFromURL(aTile, url, cache);
                     if (bitmap == null) {
@@ -140,25 +141,8 @@ public class WebSourceTileLayer extends TileLayer implements MapboxConstants {
 
             TileLoadedListener listener2 = downloader.getTileLoadedListener();
             if (listener2 != null) {
-                //create the CacheableBitmapDrawable object from the bitmap
-                result = cache.createCacheableBitmapDrawable(resultBitmap, aTile);
-
-                //pass it to onTileLoaded callback for customization, and return the customized CacheableBitmapDrawable object
-                result = listener2.onTileLoaded(result);
-
-                //null pointer checking
-                if (result != null) {
-                    int resultWidth = result.getIntrinsicWidth();
-                    int resultHeight = result.getIntrinsicHeight();
-
-                    //convert the drawable updated in onTileLoaded callback to a bitmap
-                    Bitmap bitmapToCache = Bitmap.createBitmap(resultWidth, resultHeight, Bitmap.Config.ARGB_8888);
-                    Canvas canvas = new Canvas(bitmapToCache);
-                    result.setBounds(0, 0, resultWidth, resultHeight);
-                    result.draw(canvas);
-
-                    cache.putTileBitmap(aTile, bitmapToCache);
-                }
+                Bitmap bitmap = listener2.onTileLoaded(resultBitmap, aTile);
+                result = cache.putTileBitmap(aTile, bitmap);
             } else {
                 if (resultBitmap != null) {
                     //get drawable by putting it into cache (memory and disk)

--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/util/TileLoadedListener.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/views/util/TileLoadedListener.java
@@ -5,8 +5,10 @@
 
 package com.mapbox.mapboxsdk.views.util;
 
-import uk.co.senab.bitmapcache.CacheableBitmapDrawable;
+import android.graphics.Bitmap;
+
+import com.mapbox.mapboxsdk.tileprovider.MapTile;
 
 public interface TileLoadedListener {
-    public CacheableBitmapDrawable onTileLoaded(CacheableBitmapDrawable pDrawable);
+    public Bitmap onTileLoaded(Bitmap pBitmap, MapTile pTile);
 }


### PR DESCRIPTION
The old onTileLoaded method signature is:
```java
public CacheableBitmapDrawable onTileLoaded(CacheableBitmapDrawable cacheableBitmapDrawable);
```
The new signature is:
```java
public Bitmap onTileLoaded(Bitmap pBitmap, MapTile pTile);
```

There are two advantages of this change:
1. Let the API user work with Android standard class ``Bitmap`` rather than a context specific class ``CacheableBitmapDrawable``
2. Avoid the overhead of transform ``Bitmap`` object returned to a ``CacheableBitmapDrawable`` object, and then back to a ``Bitmap`` object in ``WebSourceTileLayer.getDrawableFromTile()``. The code was:

```java
if (listener2 != null) {
                //create the CacheableBitmapDrawable object from the bitmap
                result = cache.createCacheableBitmapDrawable(resultBitmap, aTile);

                //pass it to onTileLoaded callback for customization, and return the customized CacheableBitmapDrawable object
                result = listener2.onTileLoaded(result);

                //null pointer checking
                if (result != null) {
                    int resultWidth = result.getIntrinsicWidth();
                    int resultHeight = result.getIntrinsicHeight();

                    //convert the drawable updated in onTileLoaded callback to a bitmap
                    Bitmap bitmapToCache = Bitmap.createBitmap(resultWidth, resultHeight, Bitmap.Config.ARGB_8888);
                    Canvas canvas = new Canvas(bitmapToCache);
                    result.setBounds(0, 0, resultWidth, resultHeight);
                    result.draw(canvas);

                    cache.putTileBitmap(aTile, bitmapToCache);
                }
            } ...
```
