### PR TITLE
use java.lang.Math instead of android.util.FloatMath

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/almeros/android/multitouch/TwoFingerGestureDetector.java
+++ b/MapboxAndroidSDK/src/main/java/com/almeros/android/multitouch/TwoFingerGestureDetector.java
@@ -2,7 +2,6 @@ package com.almeros.android.multitouch;
 
 import android.content.Context;
 import android.util.DisplayMetrics;
-import android.util.FloatMath;
 import android.view.MotionEvent;
 import android.view.ViewConfiguration;
 
@@ -92,7 +91,7 @@ public abstract class TwoFingerGestureDetector extends BaseGestureDetector {
         if (mCurrLen == -1) {
             final float cvx = mCurrFingerDiffX;
             final float cvy = mCurrFingerDiffY;
-            mCurrLen = FloatMath.sqrt(cvx * cvx + cvy * cvy);
+            mCurrLen = (float) Math.sqrt(cvx * cvx + cvy * cvy);
         }
         return mCurrLen;
     }
@@ -107,7 +106,7 @@ public abstract class TwoFingerGestureDetector extends BaseGestureDetector {
         if (mPrevLen == -1) {
             final float pvx = mPrevFingerDiffX;
             final float pvy = mPrevFingerDiffY;
-            mPrevLen = FloatMath.sqrt(pvx * pvx + pvy * pvy);
+            mPrevLen = (float) Math.sqrt(pvx * pvx + pvy * pvy);
         }
         return mPrevLen;
     }


### PR DESCRIPTION
Fixes #835

`FloatMath` was deprecated in Marshmallow. The recommendation is to use
`Math` instead.