### PR TITLE
raise upper bound for BoundingBox constructor

### DIFF
--- a/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/BoundingBox.java
+++ b/MapboxAndroidSDK/src/main/java/com/mapbox/mapboxsdk/geometry/BoundingBox.java
@@ -44,7 +44,7 @@ public final class BoundingBox implements Parcelable, Serializable, MapViewConst
      * @param northEast Coordinate
      * @param southWest Coordinate
      */
-    public BoundingBox(final LatLng northEast, final LatLng southWest) {
+    public BoundingBox(final ILatLng northEast, final ILatLng southWest) {
         this(northEast.getLatitude(), northEast.getLongitude(), southWest.getLatitude(), southWest.getLongitude());
     }
 


### PR DESCRIPTION
This constructor should only require an `ILatLng`